### PR TITLE
keep-alive and max-attempts Listen command options added

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ listening for only new events. This command however has few options that are ext
 --consumer= : Name of your group consumer. If not provided a name will be created as groupname-timestamp
 --reclaim= : Milliseconds of pending messages idle time, that should be reclaimed for current consumer in this group. Can be only used with group listening
 --last_id= : ID from which listener should start reading messages (using 0-0 will process all old messages)
+--keep-alive : Will keep listener alive when any unexpected non-listener related error will occur by simply restarting listening
+--max-attempts= : Number of maximum attempts to restart a listener on an unexpected non-listener related error (requires --keep-alive to be used)
 ```
 
 When `consumer` and `group` options are being in use, every message on a stream will be marked as acknowledged for the


### PR DESCRIPTION
due to another two reports of connection timeout caused by phpredis lib I decided to add a `keep-alive` command option alongside with `max-attempts` - both are optional. 

the keep-alive option will catch any unexpected errors on main `streamer->listen` method call and will simply start listener again. max-attempts option is here to limit how many times this restart will occur until command will exit - should be helpful to dont get caught in a loop of listener restarts. 

This wont affect the internal catch and store failure feature of handlers that are processing stream messages - this is only for exceptions that are going outside of that part.

DISCLAIMER - this is not a direct fix to reported phpredis connection error `RedisException  : read error on connection to localhost:6378` but more of a way to mitigate that without usage of a 3rd party app (like supervisor) 

This will also restart listener on any other `Throwable`, so keep that in mind when using this option, cause it may cause side effects.

#29 #17 