### PR TITLE
flag for model trait that emits events automatically 

### DIFF
--- a/src/Concerns/EmitsStreamerEvents.php
+++ b/src/Concerns/EmitsStreamerEvents.php
@@ -2,9 +2,9 @@
 
 namespace Prwnr\Streamer\Concerns;
 
+use Illuminate\Database\Eloquent\Model;
 use Prwnr\Streamer\Eloquent\EloquentModelEvent;
 use Prwnr\Streamer\Facades\Streamer;
-use Illuminate\Database\Eloquent\Model;
 
 /**
  * Trait EmitsStreamerEvents.
@@ -36,7 +36,7 @@ trait EmitsStreamerEvents
      */
     public function postSave(): void
     {
-        if (! $this->wasChanged()) {
+        if (!$this->wasChanged() || !$this->canStream()) {
             return;
         }
 
@@ -55,6 +55,9 @@ trait EmitsStreamerEvents
      */
     public function postCreate(): void
     {
+        if (!$this->canStream()) {
+            return;
+        }
         $payload = $this->makeBasePayload();
         foreach ($this->getAttributes() as $field => $change) {
             $payload['fields'][] = $field;
@@ -70,6 +73,10 @@ trait EmitsStreamerEvents
      */
     public function postDelete(): void
     {
+        if (!$this->canStream()) {
+            return;
+        }
+
         $payload = $this->makeBasePayload();
         $payload['deleted'] = true;
         Streamer::emit(new EloquentModelEvent($this->getEventName('deleted'), $payload));
@@ -88,7 +95,19 @@ trait EmitsStreamerEvents
     }
 
     /**
-     * @param string $action
+     * Method that can be overridden to add custom logic which will determine
+     * whether the given model should have events emitted or not.
+     * Returns true by default, emitting events for any case.
+     *
+     * @return bool
+     */
+    protected function canStream(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @param  string  $action
      * @return string
      */
     private function getEventName(string $action): string

--- a/tests/Stubs/EmittingEventsModel.php
+++ b/tests/Stubs/EmittingEventsModel.php
@@ -13,10 +13,26 @@ class EmittingEventsModel extends Model
         'foo', 'id'
     ];
 
+    private bool $shouldStream = true;
+
     public function __construct(array $attributes = [])
     {
         $this->baseEventName = 'model';
         parent::__construct($attributes);
     }
 
+    public function disableStreaming(): void
+    {
+        $this->shouldStream = false;
+    }
+
+    public function enableStreaming(): void
+    {
+        $this->shouldStream = true;
+    }
+
+    protected function canStream(): bool
+    {
+        return $this->shouldStream;
+    }
 }


### PR DESCRIPTION
resolves #38 

here is my proposition to make the automatic stream events triggered on create/change/delete "toggable" on per model basis. Im opening this by adding new `canStream` method to trait, that can be overridden in a specific model or in a parent model and extended with additional logic that will determine whether the events should be emitted or not. 