### PR TITLE
MultiStream class to handle multiple streams at once

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ Then, at any point in your application all you need to do is to emit that event 
 $event = new ExampleStreamerEvent();
 $id = \Prwnr\Streamer\Facades\Streamer::emit($event);
 ```
-This will create a message on a stream named (if such does not exists): `example.streamer.event`. Emit method will return an ID if emitting your event ended up with success. 
+This will create a message on a stream named (if such does not exist): `example.streamer.event`. Emit method will return
+an ID if emitting your event ended up with success.
 
 ### Listening for new messages on events
 
@@ -109,14 +110,17 @@ To start listening for an event, use [listen](#listen) command.
 streamer:listen example.streamer.event 
 ```
 
-This command will start listening on a given stream starting from "now". It will be listening in a blocking way, meaning
-that it will run until Redis will time out or crash. All listener related errors are being caught and logged into
+This command will start listening on a given stream (or streams separated by comma) starting from "now".
+It will be listening in a blocking way, meaning that it will run until Redis will time out or crash.
+All listener related errors are being caught and logged into
 console as well as stored in Failed Messages list for later debugging and/or retrying.
 
-That's a basic usage of this command, where event name is a required argument. So in this case it simply starts
-listening for only new events. This command however has few options that are extending its usage, those are:
+That's a basic usage of this command, where event name is a required argument (unless `--all` option is provided).
+So in this case it simply starts listening for only new events.
+This command however has few options that are extending its usage, those are:
 
 ```text
+--all= : Will trigger listener mode to start listening on all events that are registered with local listeners classes (from the ListenersStack). Event name argument is no longer required in this case.
 --group= : Name of your streaming group. Only when group is provided listener will listen on group as consumer
 --consumer= : Name of your group consumer. If not provided a name will be created as groupname-timestamp
 --reclaim= : Milliseconds of pending messages idle time, that should be reclaimed for current consumer in this group. Can be only used with group listening
@@ -139,6 +143,9 @@ using those options, keep in mind, that they are not going to take into account 
 other servers - meaning, that when first listener hooked to specific event will process its messages, the `purge` and
 `archive` options will delete the message not waiting for other listeners to finish. To fully use `archive` option
 see [Stream Archive][#stream-archive] for more details and instructions.
+
+Using multiple events in argument or the `--all` option with any other option (like group, consumer, last_id)
+will apply those options to every stream event that is being in use.
 
 #### Failed List
 

--- a/examples/6_listening.php
+++ b/examples/6_listening.php
@@ -35,7 +35,7 @@ $id = $streamer->emit($event);
 
 // Basic listen usage without using group or consumers. It will receive all messages from Stream
 // Listen method on a streamer instance allows listening for any new incoming events
-// It accepts two arguments, event name and a callback handler
+// It accepts two arguments, event name (or multiple names) and a callback handler (or multiple handlers associated to events lik [stream => handler])
 // Callback is called with argument of ReceivedMessage instance (it has message ID and content)
 // and a Streamer instance, that lets you cancel the listener loop whenever you want
 // or emit event mid loop

--- a/src/Contracts/Listener.php
+++ b/src/Contracts/Listener.php
@@ -8,8 +8,11 @@ namespace Prwnr\Streamer\Contracts;
 interface Listener
 {
     /**
-     * @param string   $event   name
-     * @param callable $handler is fired when message is read from stream (old one or a new one)
+     * @param  string|array  $events  name or multiple names of events (streams) that should be listened.
+     * @param  callable|array  $handlers  are fired when message is read from stream (old one or a new one).
+     * If one handler is passed it will be used for all the events that are being listened to.
+     * For multiple handler, the format should be: [stream => handler] - one handler for one stream.
+     *
      */
-    public function listen(string $event, callable $handler): void;
+    public function listen($events, $handlers): void;
 }

--- a/src/Contracts/Waitable.php
+++ b/src/Contracts/Waitable.php
@@ -4,6 +4,7 @@ namespace Prwnr\Streamer\Contracts;
 
 /**
  * Interface Waitable.
+ * @deprecated will be removed with next major version
  */
 interface Waitable
 {

--- a/src/EventDispatcher/Streamer.php
+++ b/src/EventDispatcher/Streamer.php
@@ -10,7 +10,6 @@ use Prwnr\Streamer\Contracts\Event;
 use Prwnr\Streamer\Contracts\History;
 use Prwnr\Streamer\Contracts\Listener;
 use Prwnr\Streamer\Contracts\Replayable;
-use Prwnr\Streamer\Contracts\Waitable;
 use Prwnr\Streamer\Exceptions\InvalidListeningArgumentsException;
 use Prwnr\Streamer\History\Snapshot;
 use Prwnr\Streamer\Stream;
@@ -265,10 +264,11 @@ class Streamer implements Emitter, Listener
 
     /**
      * @param  string  $id
-     * @param  Waitable  $on
+     * @param  Stream  $on
      * @param  Throwable  $ex
+     * @return void
      */
-    private function report(string $id, Waitable $on, Throwable $ex): void
+    private function report(string $id, Stream $on, Throwable $ex): void
     {
         $error = "Listener error. Failed processing message with ID $id on '{$on->getName()}' stream. Error: {$ex->getMessage()}";
         Log::error($error);

--- a/src/EventDispatcher/Streamer.php
+++ b/src/EventDispatcher/Streamer.php
@@ -118,7 +118,7 @@ class Streamer implements Emitter, Listener
         }
 
         try {
-            $multiStream = new Stream\MultiStream($events, $this->consumer, $this->group);
+            $multiStream = new Stream\MultiStream($events, $this->group, $this->consumer);
             $this->listenOn($multiStream, $handlers);
         } finally {
             $this->inLoop = false;

--- a/src/EventDispatcher/Streamer.php
+++ b/src/EventDispatcher/Streamer.php
@@ -204,6 +204,9 @@ class Streamer implements Emitter, Listener
     private function parseArgs($events, $handlers): array
     {
         $eventsList = Arr::wrap($events);
+        if (is_array($handlers) && count($eventsList) === 1 && count($handlers) > 1) {
+            throw new InvalidListeningArgumentsException();
+        }
 
         if (is_callable($handlers)) {
             return [$eventsList, [$handlers]];

--- a/src/Exceptions/AcknowledgingFailedException.php
+++ b/src/Exceptions/AcknowledgingFailedException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Prwnr\Streamer\Exceptions;
+
+class AcknowledgingFailedException extends \Exception
+{
+
+}

--- a/src/Exceptions/InvalidListeningArgumentsException.php
+++ b/src/Exceptions/InvalidListeningArgumentsException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Prwnr\Streamer\Exceptions;
+
+class InvalidListeningArgumentsException extends \Exception
+{
+    public function __construct()
+    {
+        parent::__construct('Not all events have handlers that can process their messages.');
+    }
+}

--- a/src/ListenersStack.php
+++ b/src/ListenersStack.php
@@ -55,6 +55,28 @@ final class ListenersStack
     }
 
     /**
+     * @param  string  $event
+     * @return bool
+     */
+    public static function hasListener(string $event): bool
+    {
+        return isset(self::$events[$event]);
+    }
+
+    /**
+     * @param  string  $event
+     * @return array
+     */
+    public static function getListenersFor(string $event): array
+    {
+        if (self::hasListener($event)) {
+            return self::$events[$event];
+        }
+
+        return [];
+    }
+
+    /**
      * @return array
      */
     public static function all(): array

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -152,6 +152,10 @@ class Stream
     public function pending(string $group, ?string $consumer = null): array
     {
         $pending = $this->redis()->xPending($this->name, $group);
+        if (!$pending) {
+            return [];
+        }
+
         $pendingCount = array_shift($pending);
 
         if ($consumer) {

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -5,13 +5,12 @@ namespace Prwnr\Streamer;
 use BadMethodCallException;
 use Prwnr\Streamer\Concerns\ConnectsWithRedis;
 use Prwnr\Streamer\Contracts\StreamableMessage;
-use Prwnr\Streamer\Contracts\Waitable;
 use Prwnr\Streamer\Stream\Range;
 
 /**
  * Class Stream.
  */
-class Stream implements Waitable
+class Stream
 {
     use ConnectsWithRedis;
 

--- a/src/Stream/Consumer.php
+++ b/src/Stream/Consumer.php
@@ -4,13 +4,13 @@ namespace Prwnr\Streamer\Stream;
 
 use Exception;
 use Prwnr\Streamer\Concerns\ConnectsWithRedis;
-use Prwnr\Streamer\Contracts\Waitable;
+use Prwnr\Streamer\Exceptions\AcknowledgingFailedException;
 use Prwnr\Streamer\Stream;
 
 /**
  * Class Consumer.
  */
-class Consumer implements Waitable
+class Consumer
 {
     use ConnectsWithRedis;
 
@@ -69,7 +69,7 @@ class Consumer implements Waitable
     {
         $result = $this->redis()->xAck($this->stream->getName(), $this->group, [$id]);
         if ($result === 0) {
-            throw new Exception("Could not acknowledge message with ID $id");
+            throw new AcknowledgingFailedException("Could not acknowledge message with ID $id");
         }
     }
 

--- a/src/Stream/MultiStream.php
+++ b/src/Stream/MultiStream.php
@@ -1,0 +1,268 @@
+<?php
+
+namespace Prwnr\Streamer\Stream;
+
+use Exception;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
+use Prwnr\Streamer\Concerns\ConnectsWithRedis;
+use Prwnr\Streamer\Contracts\StreamableMessage;
+use Prwnr\Streamer\Stream;
+
+class MultiStream
+{
+    use ConnectsWithRedis;
+
+    /** @var Collection&Stream[] */
+    private Collection $streams;
+    private string $consumer;
+    private string $group;
+
+    /**
+     * MultiStream constructor.
+     *
+     * @param  array  $streams
+     * @param  string  $consumer
+     * @param  string  $group
+     */
+    public function __construct(array $streams, string $consumer = '', string $group = '')
+    {
+        $this->streams = new Collection();
+
+        foreach ($streams as $name) {
+            if (!$name || !is_string($name)) {
+                continue;
+            }
+
+            $stream = new Stream($name);
+            $this->streams->put($name, $stream);
+
+            if ($consumer && $group) {
+                $stream->createGroup($group);
+            }
+        }
+
+        $this->consumer = $consumer;
+        $this->group = $group;
+    }
+
+    /**
+     * @return Collection&Stream[]
+     */
+    public function getStreams(): Collection
+    {
+        return $this->streams;
+    }
+
+    /**
+     * @return string
+     */
+    public function getNewEntriesKey(): string
+    {
+        if ($this->consumer && $this->group) {
+            return Consumer::NEW_ENTRIES;
+        }
+
+        return Stream::NEW_ENTRIES;
+    }
+
+    /**
+     * Adds new message to Streams (if such is in MultiStream collection).
+     *
+     * @param  array  $streams  [stream => id] format. if ID is not a string, assuming "*"
+     * @param  StreamableMessage  $message
+     * @return array
+     */
+    public function add(array $streams, StreamableMessage $message): array
+    {
+        $added = [];
+        foreach ($streams as $stream => $id) {
+            if (!$this->streams->has($stream)) {
+                continue;
+            }
+
+            if (!is_string($id)) {
+                $id = '*';
+            }
+
+            $added[$stream] = $this->streams->get($stream)->add($message, $id);
+        }
+
+        return $added;
+    }
+
+    /**
+     * Deletes message from a Stream (if such is in MultiStream collection)
+     *
+     * @param  array  $streams  [stream => [ids]] format
+     * @return int
+     */
+    public function delete(array $streams): int
+    {
+        $deleted = 0;
+        foreach ($streams as $stream => $ids) {
+            if (!$this->streams->has($stream)) {
+                continue;
+            }
+
+            $deleted += $this->redis()->xDel($stream, Arr::wrap($ids));
+        }
+
+        return $deleted;
+    }
+
+    /**
+     * @param  string  $lastSeenId
+     * @param  int  $timeout
+     * @return array|null
+     */
+    public function await(string $lastSeenId = '', int $timeout = 0): ?array
+    {
+        if (!$lastSeenId) {
+            $lastSeenId = $this->getNewEntriesKey();
+        }
+
+        $result = null;
+        if ($this->streams->count() === 1) {
+            return $this->parseResult($this->awaitSingle($this->streams->first(), $lastSeenId, $timeout));
+        }
+
+        if (!$result) {
+            $result = $this->awaitMultiple($lastSeenId, $timeout);
+        }
+
+        if (!is_array($result) || empty($result)) {
+            return [];
+        }
+
+        return $this->sortByTimestamps($this->parseResult($result));
+    }
+
+    /**
+     * Acknowledges multiple messages if MultiStream has a group.
+     *
+     * @param  array  $streams  [stream => [ids]] format
+     * @return void
+     * @throws Exception
+     */
+    public function acknowledge(array $streams): void
+    {
+        if (!$this->group) {
+            return;
+        }
+
+        $notAcknowledged = [];
+        foreach ($streams as $stream => $ids) {
+            if (!$this->streams->has($stream)) {
+                continue;
+            }
+
+            $result = $this->redis()->xAck($stream, $this->group, Arr::wrap($ids));
+            if ($result === 0) {
+                $notAcknowledged[] = $stream;
+            }
+        }
+
+        if ($notAcknowledged) {
+            throw new Exception("Not all messages were acknowledged. Streams affected: ".implode(', ',
+                    $notAcknowledged));
+        }
+    }
+
+    /**
+     * @param  Stream  $stream
+     * @param  string  $lastSeenId
+     * @param  int  $timeout
+     * @return array|null
+     */
+    private function awaitSingle(Stream $stream, string $lastSeenId, int $timeout): ?array
+    {
+        if (!$this->consumer && !$this->group) {
+            return $stream->await($lastSeenId, $timeout);
+        }
+
+        $consumer = new Consumer($this->consumer, $stream, $this->group);
+        if (!$lastSeenId) {
+            $lastSeenId = $consumer->getNewEntriesKey();
+        }
+
+        return $consumer->await($lastSeenId, $timeout);
+    }
+
+    /**
+     * @param  string  $lastSeenId
+     * @param  int  $timeout
+     * @return array|\Redis
+     */
+    private function awaitMultiple(string $lastSeenId, int $timeout)
+    {
+        $streams = $this->streams->map(static fn(Stream $s) => $lastSeenId)->toArray();
+
+        if (!$this->consumer || !$this->group) {
+            return $this->redis()->xRead($streams, null, $timeout);
+        }
+
+        return $this->redis()->xReadGroup($this->group, $this->consumer, $streams, null, $timeout);
+    }
+
+    /**
+     * @param  array  $list
+     * @return array
+     */
+    protected function sortByTimestamps(array $list): array
+    {
+        usort($list, static function ($a, $b) {
+            $aID = $a['id'] ?? null;
+            $bID = $b['id'] ?? null;
+            if ($aID === $bID) {
+                return 0;
+            }
+
+            [$aTimestamp, $aSequence] = explode("-", $aID);
+            [$bTimestamp, $bSequence] = explode("-", $bID);
+
+            if ($aTimestamp === $bTimestamp) {
+                if ($aSequence > $bSequence) {
+                    return 1;
+                }
+
+                if ($aSequence < $bSequence) {
+                    return -1;
+                }
+
+                return 0;
+            }
+
+            if ($aTimestamp > $bTimestamp) {
+                return 1;
+            }
+
+            if ($aTimestamp < $bTimestamp) {
+                return -1;
+            }
+
+            return 0;
+        });
+
+        return $list;
+    }
+
+    /**
+     * @param $result
+     * @return array
+     */
+    private function parseResult($result): array
+    {
+        $list = [];
+        foreach ($result as $stream => $messages) {
+            foreach ($messages as $id => $message) {
+                $list[] = [
+                    'stream' => $stream,
+                    'id' => $id,
+                    'message' => $message
+                ];
+            }
+        }
+        return $list;
+    }
+}

--- a/src/Stream/MultiStream.php
+++ b/src/Stream/MultiStream.php
@@ -26,7 +26,7 @@ class MultiStream
      * @param  string  $consumer
      * @param  string  $group
      */
-    public function __construct(array $streams, string $consumer = '', string $group = '')
+    public function __construct(array $streams, string $group = '', string $consumer = '')
     {
         $this->streams = new Collection();
 

--- a/tests/ListCommandTest.php
+++ b/tests/ListCommandTest.php
@@ -33,10 +33,10 @@ class ListCommandTest extends TestCase
         ListenersStack::add('other.foo.bar', AnotherLocalListener::class);
 
         $this->artisan('streamer:list', ['--compact' => true])
-            ->expectsOutput(' Event                  ')
-            ->expectsOutput(' example.streamer.event ')
-            ->expectsOutput(' foo.bar                ')
-            ->expectsOutput(' other.foo.bar          ')
+            ->expectsOutput('Event                  ')
+            ->expectsOutput('example.streamer.event ')
+            ->expectsOutput('foo.bar                ')
+            ->expectsOutput('other.foo.bar          ')
             ->assertExitCode(0);
     }
 }

--- a/tests/ListenersStackTest.php
+++ b/tests/ListenersStackTest.php
@@ -86,4 +86,39 @@ class ListenersStackTest extends TestCase
 
         $this->assertEquals($expected, ListenersStack::all());
     }
+
+    public function test_listeners_stack_has_listener_for_event(): void
+    {
+        $expected = [
+            'foo.bar' => [
+                LocalListener::class,
+                AnotherLocalListener::class
+            ],
+            'bar.foo' => LocalListener::class
+        ];
+
+        ListenersStack::addMany($expected);
+
+        $this->assertTrue(ListenersStack::hasListener('foo.bar'));
+        $this->assertTrue(ListenersStack::hasListener('bar.foo'));
+    }
+
+    public function test_listeners_stack_get_listeners_for_event(): void
+    {
+        $expected = [
+            'foo.bar' => [
+                LocalListener::class,
+                AnotherLocalListener::class
+            ],
+            'bar.foo' => LocalListener::class
+        ];
+
+        ListenersStack::addMany($expected);
+
+        $this->assertEquals([
+            LocalListener::class,
+            AnotherLocalListener::class
+        ], ListenersStack::getListenersFor('foo.bar'));
+        $this->assertEquals([LocalListener::class], ListenersStack::getListenersFor('bar.foo'));
+    }
 }

--- a/tests/MultiStreamTest.php
+++ b/tests/MultiStreamTest.php
@@ -36,7 +36,7 @@ class MultiStreamTest extends TestCase
 
     public function test_new_multi_streams_with_consumer_and_group(): void
     {
-        $multi = new MultiStream(['foo', 'bar'], 'consumer', 'group');
+        $multi = new MultiStream(['foo', 'bar'], 'group', 'consumer');
 
         $this->assertCount(2, $multi->streams());
         $streams = $multi->streams();
@@ -144,7 +144,7 @@ class MultiStreamTest extends TestCase
 
     public function test_awaits_single_stream_consumer_new_messages(): void
     {
-        $multi = new MultiStream(['foo'], 'consumer', 'group');
+        $multi = new MultiStream(['foo'], 'group', 'consumer');
 
         $multi->add(['foo' => '1-0'], $this->makeMessage());
         $multi->add(['foo' => '2-0'], $this->makeMessage());
@@ -169,7 +169,7 @@ class MultiStreamTest extends TestCase
 
     public function test_awaits_multiple_stream_consumer_new_messages(): void
     {
-        $multi = new MultiStream(['foo', 'bar'], 'consumer', 'group');
+        $multi = new MultiStream(['foo', 'bar'], 'group', 'consumer');
 
         $multi->add(['foo' => '1-0', 'bar' => '1-0'], $this->makeMessage());
         $multi->add(['foo' => '2-0', 'bar' => '2-0'], $this->makeMessage());
@@ -204,7 +204,7 @@ class MultiStreamTest extends TestCase
 
     public function test_acknowledges_messages_for_consumer(): void
     {
-        $multi = new MultiStream(['foo', 'bar'], 'consumer', 'group');
+        $multi = new MultiStream(['foo', 'bar'], 'group', 'consumer');
 
         $multi->add(['foo' => '1-0', 'bar' => '1-0'], $this->makeMessage());
         $multi->add(['foo' => '2-0', 'bar' => '2-0'], $this->makeMessage());
@@ -223,7 +223,7 @@ class MultiStreamTest extends TestCase
 
     public function test_not_all_streams_are_acknowledged(): void
     {
-        $multi = new MultiStream(['foo', 'bar'], 'consumer', 'group');
+        $multi = new MultiStream(['foo', 'bar'], 'group', 'consumer');
 
         $multi->add(['foo' => '1-0', 'bar' => '3-0'], $this->makeMessage());
 

--- a/tests/MultiStreamTest.php
+++ b/tests/MultiStreamTest.php
@@ -1,0 +1,244 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Foundation\Testing\Concerns\InteractsWithRedis;
+use Prwnr\Streamer\Stream;
+use Prwnr\Streamer\Stream\MultiStream;
+
+class MultiStreamTest extends TestCase
+{
+    use InteractsWithRedis;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setUpRedis();
+        $this->redis['phpredis']->connection()->flushall();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        $this->redis['phpredis']->connection()->flushall();
+        $this->tearDownRedis();
+    }
+
+    public function test_new_multi_streams(): void
+    {
+        $multi = new MultiStream(['foo', 'bar']);
+
+        $this->assertCount(2, $multi->getStreams());
+        $streams = $multi->getStreams();
+        $this->assertArrayHasKey('foo', $streams);
+        $this->assertArrayHasKey('bar', $streams);
+    }
+
+    public function test_new_multi_streams_with_consumer_and_group(): void
+    {
+        $multi = new MultiStream(['foo', 'bar'], 'consumer', 'group');
+
+        $this->assertCount(2, $multi->getStreams());
+        $streams = $multi->getStreams();
+        $this->assertArrayHasKey('foo', $streams);
+        $this->assertArrayHasKey('bar', $streams);
+
+        $this->assertTrue($streams->get('foo')->groupExists('group'));
+        $this->assertTrue($streams->get('bar')->groupExists('group'));
+    }
+
+    public function test_add_new_message_to_one_of_the_streams(): void
+    {
+        $multi = new MultiStream(['foo', 'bar']);
+
+        $ids = $multi->add(['foo' => '1-0', 'bar' => '1-0'], $this->makeMessage());
+        $fooBarIds = $multi->add(['foobar' => '1-0'], $this->makeMessage());
+
+        $this->assertNotEmpty($ids);
+        $this->assertCount(2, $ids);
+        $this->assertEquals([
+            'foo' => '1-0',
+            'bar' => '1-0',
+        ], $ids);
+
+        $this->assertEmpty($fooBarIds);
+    }
+
+    public function test_deletes_message_from_one_of_the_streams(): void
+    {
+        $multi = new MultiStream(['foo', 'bar']);
+        $foobar = new Stream('foobar');
+
+        $ids = $multi->add(['foo' => null, 'bar' => null], $this->makeMessage());
+        $foobarId = $foobar->add($this->makeMessage());
+
+        $deleted = $multi->delete(['foo' => [$ids['foo']], 'bar' => [$ids['bar']]]);
+        $foobarDeleted = $multi->delete(['foobar', [$foobarId]]);
+
+        $this->assertEquals(2, $deleted);
+        $this->assertEquals(0, $foobarDeleted);
+    }
+
+    public function test_awaits_messages_from_single_stream(): void
+    {
+        $multi = new MultiStream(['foo']);
+
+        $multi->add(['foo' => '1-0'], $this->makeMessage());
+        $multi->add(['foo' => '2-0'], $this->makeMessage());
+
+        $result = $multi->await('0-0');
+
+        $this->assertNotEmpty($result);
+        $this->assertCount(2, $result);
+        $this->assertEquals([
+            [
+                'stream' => 'foo',
+                'id' => '1-0',
+                'message' => ['foo' => 'bar']
+            ],
+            [
+                'stream' => 'foo',
+                'id' => '2-0',
+                'message' => ['foo' => 'bar']
+            ],
+        ], $result);
+
+        $result = $multi->await('3-0', 1);
+        $this->assertEmpty($result);
+    }
+
+    public function test_awaits_messages_from_multiple_streams(): void
+    {
+        $multi = new MultiStream(['foo', 'bar']);
+
+        $multi->add(['foo' => '1-0', 'bar' => '1-0'], $this->makeMessage());
+        $multi->add(['foo' => '2-0', 'bar' => '2-0'], $this->makeMessage());
+
+        $result = $multi->await('0-0');
+
+        $this->assertNotEmpty($result);
+        $this->assertCount(4, $result);
+        $this->assertEquals([
+            [
+                'stream' => 'foo',
+                'id' => '1-0',
+                'message' => ['foo' => 'bar']
+            ],
+            [
+                'stream' => 'bar',
+                'id' => '1-0',
+                'message' => ['foo' => 'bar']
+            ],
+            [
+                'stream' => 'foo',
+                'id' => '2-0',
+                'message' => ['foo' => 'bar']
+            ],
+            [
+                'stream' => 'bar',
+                'id' => '2-0',
+                'message' => ['foo' => 'bar']
+            ],
+        ], $result);
+    }
+
+    public function test_awaits_single_stream_consumer_new_messages(): void
+    {
+        $multi = new MultiStream(['foo'], 'consumer', 'group');
+
+        $multi->add(['foo' => '1-0'], $this->makeMessage());
+        $multi->add(['foo' => '2-0'], $this->makeMessage());
+
+        $result = $multi->await();
+
+        $this->assertNotEmpty($result);
+        $this->assertCount(2, $result);
+        $this->assertEquals([
+            [
+                'stream' => 'foo',
+                'id' => '1-0',
+                'message' => ['foo' => 'bar']
+            ],
+            [
+                'stream' => 'foo',
+                'id' => '2-0',
+                'message' => ['foo' => 'bar']
+            ],
+        ], $result);
+    }
+
+    public function test_awaits_multiple_stream_consumer_new_messages(): void
+    {
+        $multi = new MultiStream(['foo', 'bar'], 'consumer', 'group');
+
+        $multi->add(['foo' => '1-0', 'bar' => '1-0'], $this->makeMessage());
+        $multi->add(['foo' => '2-0', 'bar' => '2-0'], $this->makeMessage());
+
+        $result = $multi->await();
+
+        $this->assertNotEmpty($result);
+        $this->assertCount(4, $result);
+        $this->assertEquals([
+            [
+                'stream' => 'foo',
+                'id' => '1-0',
+                'message' => ['foo' => 'bar']
+            ],
+            [
+                'stream' => 'bar',
+                'id' => '1-0',
+                'message' => ['foo' => 'bar']
+            ],
+            [
+                'stream' => 'foo',
+                'id' => '2-0',
+                'message' => ['foo' => 'bar']
+            ],
+            [
+                'stream' => 'bar',
+                'id' => '2-0',
+                'message' => ['foo' => 'bar']
+            ],
+        ], $result);
+    }
+
+    public function test_acknowledges_messages_for_consumer(): void
+    {
+        $multi = new MultiStream(['foo', 'bar'], 'consumer', 'group');
+
+        $multi->add(['foo' => '1-0', 'bar' => '1-0'], $this->makeMessage());
+        $multi->add(['foo' => '2-0', 'bar' => '2-0'], $this->makeMessage());
+
+        $result = $multi->await();
+
+        $this->assertNotEmpty($result);
+        $this->assertCount(4, $result);
+
+        $multi->acknowledge(['foo' => ['1-0'], ['bar' => ['1-0', '2-0']]]);
+
+        $consumer = new Stream\Consumer('consumer', $multi->getStreams()->get('foo'), 'group');
+
+        $this->assertCount(1, $consumer->pending());
+    }
+
+    public function test_not_all_streams_are_acknowledged(): void
+    {
+        $multi = new MultiStream(['foo', 'bar'], 'consumer', 'group');
+
+        $multi->add(['foo' => '1-0', 'bar' => '3-0'], $this->makeMessage());
+
+        $result = $multi->await();
+
+        $this->assertNotEmpty($result);
+        $this->assertCount(2, $result);
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Not all messages were acknowledged. Streams affected: bar');
+
+        $multi->acknowledge(['foo' => ['1-0'], 'bar' => ['1-0', '2-0']]);
+
+        $consumer = new Stream\Consumer('consumer', $multi->getStreams()->get('foo'), 'group');
+
+        $this->assertCount(0, $consumer->pending());
+    }
+}

--- a/tests/MultiStreamTest.php
+++ b/tests/MultiStreamTest.php
@@ -28,8 +28,8 @@ class MultiStreamTest extends TestCase
     {
         $multi = new MultiStream(['foo', 'bar']);
 
-        $this->assertCount(2, $multi->getStreams());
-        $streams = $multi->getStreams();
+        $this->assertCount(2, $multi->streams());
+        $streams = $multi->streams();
         $this->assertArrayHasKey('foo', $streams);
         $this->assertArrayHasKey('bar', $streams);
     }
@@ -38,8 +38,8 @@ class MultiStreamTest extends TestCase
     {
         $multi = new MultiStream(['foo', 'bar'], 'consumer', 'group');
 
-        $this->assertCount(2, $multi->getStreams());
-        $streams = $multi->getStreams();
+        $this->assertCount(2, $multi->streams());
+        $streams = $multi->streams();
         $this->assertArrayHasKey('foo', $streams);
         $this->assertArrayHasKey('bar', $streams);
 
@@ -216,7 +216,7 @@ class MultiStreamTest extends TestCase
 
         $multi->acknowledge(['foo' => ['1-0'], ['bar' => ['1-0', '2-0']]]);
 
-        $consumer = new Stream\Consumer('consumer', $multi->getStreams()->get('foo'), 'group');
+        $consumer = new Stream\Consumer('consumer', $multi->streams()->get('foo'), 'group');
 
         $this->assertCount(1, $consumer->pending());
     }
@@ -237,7 +237,7 @@ class MultiStreamTest extends TestCase
 
         $multi->acknowledge(['foo' => ['1-0'], 'bar' => ['1-0', '2-0']]);
 
-        $consumer = new Stream\Consumer('consumer', $multi->getStreams()->get('foo'), 'group');
+        $consumer = new Stream\Consumer('consumer', $multi->streams()->get('foo'), 'group');
 
         $this->assertCount(0, $consumer->pending());
     }

--- a/tests/Stubs/FooBarStreamerEventStub.php
+++ b/tests/Stubs/FooBarStreamerEventStub.php
@@ -4,7 +4,7 @@ namespace Tests\Stubs;
 
 use Prwnr\Streamer\Contracts\Event;
 
-class StreamerEventStub implements Event
+class FooBarStreamerEventStub implements Event
 {
     public function name(): string
     {

--- a/tests/Stubs/OtherBarStreamerEventStub.php
+++ b/tests/Stubs/OtherBarStreamerEventStub.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests\Stubs;
+
+use Prwnr\Streamer\Contracts\Event;
+
+class OtherBarStreamerEventStub implements Event
+{
+    public function name(): string
+    {
+        return 'other.bar';
+    }
+
+    public function type(): string
+    {
+        return Event::TYPE_EVENT;
+    }
+
+    public function payload(): array
+    {
+        return ['other' => 'bar'];
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -14,9 +14,9 @@ use Prwnr\Streamer\Facades\Streamer;
 use Prwnr\Streamer\ListenersStack;
 use Prwnr\Streamer\Stream;
 use Prwnr\Streamer\StreamerProvider;
+use Tests\Stubs\FooBarStreamerEventStub;
 use Tests\Stubs\LocalListener;
 use Tests\Stubs\MessageStub;
-use Tests\Stubs\StreamerEventStub;
 
 class TestCase extends \Orchestra\Testbench\TestCase
 {
@@ -41,7 +41,7 @@ class TestCase extends \Orchestra\Testbench\TestCase
 
     protected function makeEvent(): Event
     {
-        return new StreamerEventStub();
+        return new FooBarStreamerEventStub();
     }
 
     protected function withLocalListenersConfigured(array $listeners): void


### PR DESCRIPTION
MultiStreams summary.

1. Streamer dispatcher got changed that it can accept either one stream and one handler or multiple streams and multiple (or one) handler
2. Listen command can work in two ways: a) with its first arg passed as list of events like: `foo.bar,foobar,some.bar` b) skipping the arg and using option `--all` that will use all events that are registered in Listener Stack

using other command arguments with multiple streams will always apply them to all of the streams (so, like last_id for example). 
Claiming pending messages also happens for all the streams. 

this command can have bottlenecks for multiple streams, as it will have to process every message for every stream and every listener before coming back to awaiting for new messages.  