### PR TITLE
Removed xRead deprecation exceptions

### DIFF
--- a/src/Stream/MultiStream.php
+++ b/src/Stream/MultiStream.php
@@ -188,7 +188,7 @@ class MultiStream
         $streams = $this->streams->map(static fn (Stream $s): string => $lastSeenId)->toArray();
 
         if (!$this->consumer || !$this->group) {
-            $result = $this->redis()->xRead($streams, null, $timeout);
+            $result = $this->redis()->xRead($streams, -1, $timeout);
             if (!is_array($result)) {
                 return [];
             }
@@ -196,7 +196,7 @@ class MultiStream
             return $result;
         }
 
-        $result = $this->redis()->xReadGroup($this->group, $this->consumer, $streams, null, $timeout);
+        $result = $this->redis()->xReadGroup($this->group, $this->consumer, $streams, -1, $timeout);
         if (!is_array($result)) {
             return [];
         }

--- a/src/Stream/MultiStream.php
+++ b/src/Stream/MultiStream.php
@@ -188,7 +188,7 @@ class MultiStream
         $streams = $this->streams->map(static fn (Stream $s): string => $lastSeenId)->toArray();
 
         if (!$this->consumer || !$this->group) {
-            $result = $this->redis()->xRead($streams, -1, $timeout);
+            $result = $this->redis()->xRead($streams, 0, $timeout);
             if (!is_array($result)) {
                 return [];
             }
@@ -196,7 +196,7 @@ class MultiStream
             return $result;
         }
 
-        $result = $this->redis()->xReadGroup($this->group, $this->consumer, $streams, -1, $timeout);
+        $result = $this->redis()->xReadGroup($this->group, $this->consumer, $streams, 0, $timeout);
         if (!is_array($result)) {
             return [];
         }


### PR DESCRIPTION
Removed xRead deprecation exceptions by switching from passing null to a default -1 as count

`Redis::xread(): Passing null to parameter #2 ($count) of type int is deprecated`

<img width="1089" alt="Screenshot 2024-12-09 at 13 00 14" src="https://github.com/user-attachments/assets/ac417473-5c27-47a6-9e60-43b054289b34">
