### PR TITLE
Add config option to prevent message acknowledgment on any listener failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,26 +387,24 @@ has been taken.
 Check example's directory in this package to see how can you exactly use each command with package Stream and Consumer
 instances.
 
+### Always Acknowledge
 
-### Acknowledge on Any Listener Failure
-
-A new configuration option is available in `config/streamer.php`:
+A configuration option is available in `config/streamer.php`:
 
 ```php
-'ack_on_any_listener_failure' => env('STREAMER_ACK_ON_LISTENER_FAILURE', false),
+'always_acknowledge' => env('STREAMER_ALWAYS_ACKNOWLEDGE', true),
 ```
 
 **Description:**
 
-- If set to `true`, messages will only be acknowledged if all listeners succeed.
-- If any listener fails, the message will remain pending for the group/consumer and can be retried later.
-- If set to `false` (the default), messages are acknowledged after the handler, even if some listeners fail (backwards compatible behavior).
-- You can also control this via the `STREAMER_ACK_ON_LISTENER_FAILURE` environment variable.
+- If set to `true` (the default), messages are acknowledged after the handler, even if some listeners fail (backwards compatible behavior).
+- If set to `false`, messages will only be acknowledged if all listeners succeed. If any listener fails, the message will remain pending for the group/consumer and can be retried later.
+- You can also control this via the `STREAMER_ALWAYS_ACKNOWLEDGE` environment variable.
 
 **Use case:**
 
-This option is useful when you want to ensure that all listeners have successfully processed a message before it is acknowledged and removed from the pending list. If any listener fails, the message will not be acknowledged, allowing for retries and improved reliability in distributed event processing.
+This option is useful when you want to ensure that all listeners have successfully processed a message before it is acknowledged and removed from the pending list. If any listener fails and this is set to false, the message will not be acknowledged, allowing for retries and improved reliability in distributed event processing.
 
 **Note on Retries and Redis Streams Best Practices:**
 
-While this library provides a retry function for failed messages, relying on retries as a primary recovery mechanism is considered an anti-pattern when using Redis Streams. Redis Streams are designed for at-least-once delivery, and the most robust approach is to acknowledge messages only after all listeners have successfully processed them. This ensures that no message is lost or processed incompletely, and avoids the pitfalls of repeated failures and message buildup in the pending list. The `ack_on_any_listener_failure` option enforces this best practice by keeping messages pending until all listeners succeed, making retries a fallback rather than the main strategy.
+While this library provides a retry function for failed messages, relying on retries as a primary recovery mechanism is considered an anti-pattern when using Redis Streams. Redis Streams are designed for at-least-once delivery, and the most robust approach is to acknowledge messages only after all listeners have successfully processed them. This ensures that no message is lost or processed incompletely, and avoids the pitfalls of repeated failures and message buildup in the pending list. Setting `always_acknowledge` to false enforces this best practice by keeping messages pending until all listeners succeed, making retries a fallback rather than the main strategy.

--- a/config/streamer.php
+++ b/config/streamer.php
@@ -44,16 +44,14 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Acknowledge on Any Listener Failure
+    | Always Acknowledge
     |--------------------------------------------------------------------------
     |
-    | If true, messages will only be acknowledged if all listeners succeed.
-    | If any listener fails, the message will remain pending for the group/consumer
-    | and can be retried later. If false, messages are acknowledged after the handler
-    | even if some listeners fail (backwards compatible).
+    | If true (default), messages will be acknowledged after the handler, even if some listeners fail (backwards compatible).
+    | If false, messages will only be acknowledged if all listeners succeed. If any listener fails, the message will remain pending for the group/consumer and can be retried later.
     |
     */
-    'ack_on_any_listener_failure' => env('STREAMER_ACK_ON_LISTENER_FAILURE', false),
+    'always_acknowledge' => env('STREAMER_ALWAYS_ACKNOWLEDGE', true),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/streamer.php
+++ b/config/streamer.php
@@ -44,6 +44,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Acknowledge on Any Listener Failure
+    |--------------------------------------------------------------------------
+    |
+    | If true, messages will only be acknowledged if all listeners succeed.
+    | If any listener fails, the message will remain pending for the group/consumer
+    | and can be retried later. If false, messages are acknowledged after the handler
+    | even if some listeners fail (backwards compatible).
+    |
+    */
+    'ack_on_any_listener_failure' => env('STREAMER_ACK_ON_LISTENER_FAILURE', false),
+
+    /*
+    |--------------------------------------------------------------------------
     | Streamer Redis connection
     |--------------------------------------------------------------------------
     |

--- a/src/Commands/ListenCommand.php
+++ b/src/Commands/ListenCommand.php
@@ -17,6 +17,7 @@ use Prwnr\Streamer\Stream;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 use Throwable;
+use Prwnr\Streamer\Exceptions\ListenerFailedException;
 
 /**
  * Class ListenCommand.
@@ -113,10 +114,10 @@ class ListenCommand extends Command
             }
 
             if ($failed) {
-                if (config('streamer.ack_on_any_listener_failure', false)) {
-                    throw new \Prwnr\Streamer\Exceptions\ListenerFailedException('At least one listener failed');
+                if (config('streamer.always_acknowledge', true)) {
+                    return;
                 }
-                return;
+                throw new ListenerFailedException('At least one listener failed');
             }
 
             if ($this->option('archive')) {
@@ -263,7 +264,7 @@ class ListenCommand extends Command
     {
         try {
             $this->streamer->listen($events, $handler);
-        } catch (\Prwnr\Streamer\Exceptions\ListenerFailedException $e) {
+        } catch (ListenerFailedException $e) {
             // Always rethrow so Streamer can avoid acknowledging the message
             throw $e;
         } catch (Throwable $e) {

--- a/src/Commands/ListenCommand.php
+++ b/src/Commands/ListenCommand.php
@@ -113,6 +113,9 @@ class ListenCommand extends Command
             }
 
             if ($failed) {
+                if (config('streamer.ack_on_any_listener_failure', false)) {
+                    throw new \Prwnr\Streamer\Exceptions\ListenerFailedException('At least one listener failed');
+                }
                 return;
             }
 
@@ -260,6 +263,9 @@ class ListenCommand extends Command
     {
         try {
             $this->streamer->listen($events, $handler);
+        } catch (\Prwnr\Streamer\Exceptions\ListenerFailedException $e) {
+            // Always rethrow so Streamer can avoid acknowledging the message
+            throw $e;
         } catch (Throwable $e) {
             if (!$this->option('keep-alive')) {
                 throw $e;

--- a/src/Exceptions/ListenerFailedException.php
+++ b/src/Exceptions/ListenerFailedException.php
@@ -6,7 +6,9 @@ namespace Prwnr\Streamer\Exceptions;
 
 use Exception;
 
+/**
+ * Used to signal that at least one listener failed
+ */
 class ListenerFailedException extends Exception
 {
-    // Used to signal that at least one listener failed and message should not be acknowledged
 } 

--- a/src/Exceptions/ListenerFailedException.php
+++ b/src/Exceptions/ListenerFailedException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prwnr\Streamer\Exceptions;
+
+use Exception;
+
+class ListenerFailedException extends Exception
+{
+    // Used to signal that at least one listener failed and message should not be acknowledged
+} 

--- a/tests/ListenCommandTest.php
+++ b/tests/ListenCommandTest.php
@@ -542,4 +542,189 @@ class ListenCommandTest extends TestCase
 
         $this->assertNull($this->manager->driver('memory')->find('foo.bar', $id));
     }
+
+    public function test_message_is_not_acknowledged_if_any_listener_fails_and_config_flag_is_on(): void
+    {
+        $this->app['config']->set('streamer.ack_on_any_listener_failure', true);
+        $listeners = [
+            ExceptionalListener::class,
+            LocalListener::class,
+        ];
+        $this->withLocalListenersConfigured($listeners);
+        $stream = new Stream('foo.bar');
+        $group = 'testgroup';
+        $consumer = 'testconsumer';
+        // 1. Create the group first
+        $stream->createGroup($group, '0');
+        // 2. Emit the message
+        $event = $this->makeEvent();
+        $id = Streamer::emit($event);
+        // 3. Run the listen command with --last_id => '>'
+        $args = [
+            'events' => 'foo.bar',
+            '--last_id' => '>',
+            '--group' => $group,
+            '--consumer' => $consumer,
+        ];
+        $this->artisan('streamer:listen', $args)
+            ->assertExitCode(0);
+        // 4. Assert the message is pending for the consumer
+        $pending = $stream->pending($group, $consumer);
+        $pendingIds = array_map(fn($item) => $item[0], $pending);
+        $this->assertContains($id, $pendingIds);
+    }
+
+    public function test_message_is_acknowledged_if_all_listeners_succeed_and_config_flag_is_on(): void
+    {
+        $this->app['config']->set('streamer.ack_on_any_listener_failure', true);
+        $listeners = [
+            LocalListener::class,
+            AnotherLocalListener::class,
+        ];
+        $this->withLocalListenersConfigured($listeners);
+        $stream = new Stream('foo.bar');
+        $group = 'testgroup';
+        $consumer = 'testconsumer';
+        $event = $this->makeEvent();
+        $id = Streamer::emit($event);
+        // Create the group with last-delivered-id '0' so all messages are delivered
+        $stream->createGroup($group, '0');
+
+        $args = [
+            'events' => 'foo.bar',
+            '--last_id' => '0-0',
+            '--group' => $group,
+            '--consumer' => $consumer,
+        ];
+
+        $this->artisan('streamer:listen', $args)
+            ->assertExitCode(0);
+
+        // Message should NOT be pending for the group/consumer
+        $pending = $stream->pending($group, $consumer);
+        $pendingIds = array_map(fn($item) => $item[0], $pending);
+        $this->assertNotContains($id, $pendingIds);
+    }
+
+    public function test_message_is_acknowledged_on_failure_if_config_flag_is_off(): void
+    {
+        $this->app['config']->set('streamer.ack_on_any_listener_failure', false);
+        $listeners = [
+            ExceptionalListener::class,
+            LocalListener::class,
+        ];
+        $this->withLocalListenersConfigured($listeners);
+        $stream = new Stream('foo.bar');
+        $group = 'testgroup';
+        $consumer = 'testconsumer';
+        $event = $this->makeEvent();
+        $id = Streamer::emit($event);
+        // Create the group with last-delivered-id '0' so all messages are delivered
+        $stream->createGroup($group, '0');
+
+        $args = [
+            'events' => 'foo.bar',
+            '--last_id' => '0-0',
+            '--group' => $group,
+            '--consumer' => $consumer,
+        ];
+
+        $this->artisan('streamer:listen', $args)
+            ->assertExitCode(0);
+
+        // Message should NOT be pending for the group/consumer (default behavior)
+        $pending = $stream->pending($group, $consumer);
+        $pendingIds = array_map(fn($item) => $item[0], $pending);
+        $this->assertNotContains($id, $pendingIds);
+    }
+
+    public function test_group_created_after_event_delivers_previous_events(): void
+    {
+        $listeners = [
+            LocalListener::class,
+        ];
+        $this->withLocalListenersConfigured($listeners);
+        $stream = new Stream('foo.bar');
+        $group = 'lategroup1';
+        $consumer = 'lateconsumer1';
+        // 1. Emit the event before creating the group
+        $event = $this->makeEvent();
+        $id = Streamer::emit($event);
+        // 2. Create the group at '0' (after the event)
+        $stream->createGroup($group, '0');
+        // 3. Run the listen command with --last_id => '>'
+        $args = [
+            'events' => 'foo.bar',
+            '--last_id' => '>',
+            '--group' => $group,
+            '--consumer' => $consumer,
+        ];
+        $this->artisan('streamer:listen', $args)
+            ->assertExitCode(0);
+        // 4. Assert the message is NOT pending for the consumer (was acknowledged)
+        $pending = $stream->pending($group, $consumer);
+        $pendingIds = array_map(fn($item) => $item[0], $pending);
+        $this->assertNotContains($id, $pendingIds);
+    }
+
+    public function test_group_created_after_event_leaves_pending_on_failure(): void
+    {
+        $this->app['config']->set('streamer.ack_on_any_listener_failure', true);
+        $listeners = [
+            ExceptionalListener::class,
+        ];
+        $this->withLocalListenersConfigured($listeners);
+        $stream = new Stream('foo.bar');
+        $group = 'lategroup2';
+        $consumer = 'lateconsumer2';
+        // 1. Emit the event before creating the group
+        $event = $this->makeEvent();
+        $id = Streamer::emit($event);
+        // 2. Create the group at '0' (after the event)
+        $stream->createGroup($group, '0');
+        // 3. Run the listen command with --last_id => '>'
+        $args = [
+            'events' => 'foo.bar',
+            '--last_id' => '>',
+            '--group' => $group,
+            '--consumer' => $consumer,
+        ];
+        $this->artisan('streamer:listen', $args)
+            ->assertExitCode(0);
+        // 4. Assert the message IS pending for the consumer (was not acknowledged)
+        $pending = $stream->pending($group, $consumer);
+        $pendingIds = array_map(fn($item) => $item[0], $pending);
+        $this->assertContains($id, $pendingIds);
+    }
+
+    public function test_create_group_with_zero_last_delivered_id_delivers_all_messages(): void
+    {
+        $listeners = [
+            \Tests\Stubs\LocalListener::class,
+        ];
+        $this->withLocalListenersConfigured($listeners);
+        $stream = new \Prwnr\Streamer\Stream('foo.bar');
+        $group = 'testgroupzero';
+        $consumer = 'testconsumerzero';
+        // Emit multiple events before group creation
+        $event1 = $this->makeEvent();
+        $id1 = \Prwnr\Streamer\Facades\Streamer::emit($event1);
+        $event2 = $this->makeEvent();
+        $id2 = \Prwnr\Streamer\Facades\Streamer::emit($event2);
+        // Create the group with last-delivered-id '0' so all messages are delivered
+        $stream->createGroup($group, '0');
+        $args = [
+            'events' => 'foo.bar',
+            '--last_id' => '>',
+            '--group' => $group,
+            '--consumer' => $consumer,
+        ];
+        $this->artisan('streamer:listen', $args)
+            ->assertExitCode(0);
+        // Assert both messages are NOT pending for the consumer (were acknowledged)
+        $pending = $stream->pending($group, $consumer);
+        $pendingIds = array_map(fn($item) => $item[0], $pending);
+        $this->assertNotContains($id1, $pendingIds);
+        $this->assertNotContains($id2, $pendingIds);
+    }
 }


### PR DESCRIPTION

This PR introduces a new configuration option, `ack_on_any_listener_failure`, to the Streamer package:

- **New config in `config/streamer.php`:**
  ```php
  'ack_on_any_listener_failure' => env('STREAMER_ACK_ON_LISTENER_FAILURE', false),
  ```
- **Behavior:**
  - If set to `true`, messages will only be acknowledged if all listeners succeed.
  - If any listener fails, the message will remain pending for the group/consumer and can be retried later.
  - If set to `false` (the default), messages are acknowledged after the handler, even if some listeners fail (backwards compatible behavior).
  - This can also be controlled via the `STREAMER_ACK_ON_LISTENER_FAILURE` environment variable.

- **Documentation:**
  - The new option and its behavior are documented in the README under a new "Configuration" section.

**Use case:**  
This option is useful for ensuring that all listeners have successfully processed a message before it is acknowledged and removed from the pending list. If any listener fails, the message will not be acknowledged, allowing for retries and improved reliability in distributed event processing. 

**Note on Retries and Redis Streams Best Practices:**

While this library provides a retry function for failed messages, relying on retries as a primary recovery mechanism is considered an anti-pattern when using Redis Streams. Redis Streams are designed for at-least-once delivery, and the most robust approach is to acknowledge messages only after all listeners have successfully processed them. This ensures that no message is lost or processed incompletely, and avoids the pitfalls of repeated failures and message buildup in the pending list. The `ack_on_any_listener_failure` option enforces this best practice by keeping messages pending until all listeners succeed, making retries a fallback rather than the main strategy. 