### PR TITLE
add support for PHP 8.4 and remove deprecation warnings

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: ['8.1', '8.2']
+        php-version: ['8.1', '8.2', '8.3', '8.4']
         redis-version: [6, 7]
     name: PHP ${{ matrix.php-version }}, Redis ${{ matrix.redis-version }}
     steps:

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "ext-json": "*",
         "ext-redis": "*",
-        "php": "^8.1|^8.2",
+        "php": "^8.1|^8.2|^8.3|^8.4",
         "illuminate/console": "^10.0|^11.0|^12.0",
         "illuminate/support": "^10.0|^11.0|^12.0",
         "illuminate/redis": "^10.0|^11.0|^12.0",

--- a/src/Archiver/NullStorage.php
+++ b/src/Archiver/NullStorage.php
@@ -44,7 +44,7 @@ class NullStorage implements ArchiveStorage
     /**
      * @inheritDoc
      */
-    public function delete(string $event, string $id = null): int
+    public function delete(string $event, ?string $id = null): int
     {
         return 0;
     }

--- a/src/Contracts/ArchiveStorage.php
+++ b/src/Contracts/ArchiveStorage.php
@@ -40,5 +40,5 @@ interface ArchiveStorage
      * @param string|null $id without ID being passed, all messages of a given event should be deleted
      * @return int count of deleted messages
      */
-    public function delete(string $event, string $id = null): int;
+    public function delete(string $event, ?string $id = null): int;
 }

--- a/src/Contracts/History.php
+++ b/src/Contracts/History.php
@@ -18,5 +18,5 @@ interface History
      * Replays event history by its specific identifier.
      *
      */
-    public function replay(string $event, string $identifier, Carbon $until = null): array;
+    public function replay(string $event, string $identifier, ?Carbon $until = null): array;
 }

--- a/src/History/EventHistory.php
+++ b/src/History/EventHistory.php
@@ -27,7 +27,7 @@ class EventHistory implements History
      * @inheritDoc
      * @throws JsonException
      */
-    public function replay(string $event, string $identifier, Carbon $until = null): array
+    public function replay(string $event, string $identifier, ?Carbon $until = null): array
     {
         $key = $event . Snapshot::KEY_SEPARATOR . $identifier;
         $snapshots = $this->redis()->lRange($key, 0, $this->redis()->lLen($key));

--- a/tests/ArchiveStorageManagerTest.php
+++ b/tests/ArchiveStorageManagerTest.php
@@ -77,7 +77,7 @@ class ArchiveStorageManagerTest extends TestCase
                     ]);
                 }
 
-                public function delete(string $event, string $id = null): int
+                public function delete(string $event, ?string $id = null): int
                 {
                     if ($event === 'foo.bar' && $id === '123') {
                         return 1;


### PR DESCRIPTION
Hello @prwnr ,

Thank you for this cool library.

I’m using it with PHP 8.4 and noticed the following deprecation warnings:

```
[23-Sep-2025 23:52:25 UTC] PHP Deprecated:  Prwnr\Streamer\History\EventHistory::replay(): Implicitly marking parameter $until as nullable is deprecated; the explicit nullable type must be used instead in .../vendor/prwnr/laravel-streamer/src/History/EventHistory.php on line 30

[23-Sep-2025 23:52:25 UTC] PHP Deprecated:  Prwnr\Streamer\Contracts\History::replay(): Implicitly marking parameter $until as nullable is deprecated; the explicit nullable type must be used instead in .../vendor/prwnr/laravel-streamer/src/Contracts/History.php on line 21

[23-Sep-2025 23:52:25 UTC] PHP Deprecated:  Prwnr\Streamer\Archiver\NullStorage::delete(): Implicitly marking parameter $id as nullable is deprecated; the explicit nullable type must be used instead in .../vendor/prwnr/laravel-streamer/src/Archiver/NullStorage.php on line 47

[23-Sep-2025 23:52:25 UTC] PHP Deprecated:  Prwnr\Streamer\Contracts\ArchiveStorage::delete(): Implicitly marking parameter $id as nullable is deprecated; the explicit nullable type must be used instead in .../vendor/prwnr/laravel-streamer/src/Contracts/ArchiveStorage.php on line 43
```

I’ve put together a small patch that:

- fixes these deprecation warnings
- adds PHP 8.3 and 8.4 to the composer.json requirements and the GitHub Actions workflow

Hope this helps keep the library up to date! Thanks again for maintaining it.